### PR TITLE
fix: require BETTER_AUTH_SECRET env var to prevent signup crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ bun run seed             # Seed database (seed.server.ts)
 
 Required environment variables:
 - `DATABASE_URL` - PostgreSQL connection string
-- `AUTH_SECRET` - Better Auth secret key
+- `BETTER_AUTH_SECRET` - Better Auth secret key (minimum 32 characters, use `openssl rand -base64 32` to generate)
 - `BUNNY_LIBRARY_ID` - Bunny.net Video Library ID (found in Video Library settings)
 - `BUNNY_STREAM_ACCESS_KEY` - Bunny.net Stream API key (Video Library → API section)
 - `BUNNY_STORAGE_ACCESS_KEY` - Bunny.net Storage Zone password (Storage Zone → FTP & API Access)

--- a/app/lib/auth/auth.server.ts
+++ b/app/lib/auth/auth.server.ts
@@ -5,7 +5,12 @@ import { data } from "react-router";
 import db from "~/db/index.server";
 import { account, session, user, verification } from "~/db/schema";
 
+if (!process.env.BETTER_AUTH_SECRET) {
+	throw new Error("BETTER_AUTH_SECRET environment variable is required");
+}
+
 export const auth = betterAuth({
+	secret: process.env.BETTER_AUTH_SECRET,
 	database: drizzleAdapter(db, {
 		provider: "pg",
 		schema: {


### PR DESCRIPTION
## Summary
- Fixes a crash during signup caused by missing or misnamed environment variable for authentication secret
- Updates environment variable name from `AUTH_SECRET` to `BETTER_AUTH_SECRET` with validation

## Changes

### Environment Variables
- Renamed `AUTH_SECRET` to `BETTER_AUTH_SECRET` in documentation with instructions to generate a secure 32-character key

### Authentication Module
- Added runtime check to throw an error if `BETTER_AUTH_SECRET` is not set
- Updated `betterAuth` initialization to use `BETTER_AUTH_SECRET` environment variable

## Test plan
- [x] Verify that the app throws a clear error if `BETTER_AUTH_SECRET` is missing
- [x] Confirm signup flow works correctly when `BETTER_AUTH_SECRET` is set
- [x] Check that documentation reflects the updated environment variable name and usage instructions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e18b5c13-4c27-40b5-b8fe-3abf182eabf0